### PR TITLE
Updated SetVar to only take strings, quick fix for notifications

### DIFF
--- a/RelayDotNet/Relay.cs
+++ b/RelayDotNet/Relay.cs
@@ -1644,7 +1644,6 @@ namespace RelayDotNet
                 targets,
                 new Dictionary<string, object>
                 {
-                    ["_type"] = RequestType.Notification.SerializedName,
                     ["originator"] = sourceUri,
                     ["type"] = notificationType.SerializedName,
                     ["name"] = name,


### PR DESCRIPTION
Updated SetVar to only take strings as the value argument, updated notification function parameters and request payload when a notification is sent in SendNotification.