### PR TITLE
Add TriggerWorkflow, FetchDevice, and UpdateAccessToken

### DIFF
--- a/RelayDotNet/Relay.cs
+++ b/RelayDotNet/Relay.cs
@@ -2052,10 +2052,7 @@ namespace RelayDotNet
 
             // Create the uri object, and serialize the payload
             Uri uri = new Uri(url);
-
-            // var json = JsonConvert.SerializeObject(payload);
             var json = JsonSerializer.Serialize<Dictionary<string, string>>(payload);
-
             var data = new StringContent(json, Encoding.UTF8, "application/json");
 
             // Post the request, await the response

--- a/RelayDotNet/Relay.cs
+++ b/RelayDotNet/Relay.cs
@@ -1961,7 +1961,7 @@ namespace RelayDotNet
             string url = $"https://{auth_hostname}/oauth2/token";
             var grantUrl = new Uri(@url);
 
-            // Create a payload that will
+            // Create a payload to be sent with the request
             var grantPayload = new Dictionary<string, string>() {
                 ["grant_type"] = "refresh_token",
                 ["refresh_token"] = refreshToken,
@@ -1995,21 +1995,17 @@ namespace RelayDotNet
         /// A convenience method for sending an HTTP trigger to the Relay server.
         /// This generally would be used in a third-party system to start a Relay 
         /// workflow via an HTTP trigger and optionally pass data to it with
-        /// action_args.  Under the covers, this uses Python's "request" library
-        /// for using the https protocol. 
+        /// action_args.  
         /// 
         /// If the access_token has expired and the request gets a 401 response 
-        /// a new access_token will be automatically generated via the refresh_token
-        /// and the request will be resubmitted with the new access_token. Otherwise
+        /// a new access_token will be automatically generated via the refreshToken
+        /// and the request will be resubmitted with the new accessToken. Otherwise
         /// the refresh token won't be used.
         /// 
-        /// This method will return a tuple of (requests.Response, access_token)
-        /// where you can inspect the http response, and get the updated access_token
-        /// if it was updated (otherwise the original access_token will be returned).
         /// </summary>
         /// <param name="accessToken">the current access token.  Can be a placeholder value and this method will 
         /// generate a new one and return it.</param>
-        /// <param name="refreshToken">the permanent refresh_token that can be used to obtain a new access token.  
+        /// <param name="refreshToken">the permanent refresh token that can be used to obtain a new access token.  
         /// The caller should treat the refresh token as very sensitive data, and secure it appropriately.</param>
         /// <param name="clientId">the auth_sdk_id as returned from "relay env".</param>
         /// <param name="workflowId">the workflow_id as returned from "relay workflow list". Usually starts with "wf_".</param>
@@ -2092,7 +2088,7 @@ namespace RelayDotNet
         /// and this method will generate a new one and return it. If the
         /// original value of the access token passed in here has expired,
         /// this method will also generate a new one and return it.</param>
-        /// <param name="refreshToken">the permanent refresh_token that can be used to
+        /// <param name="refreshToken">the permanent refresh token that can be used to
         /// obtain a new access_token. The caller should treat the refresh
         /// token as very sensitive data, and secure it appropriately.</param>
         /// <param name="clientId">the auth_sdk_id as returned from "relay env".</param>

--- a/RelayDotNet/Relay.cs
+++ b/RelayDotNet/Relay.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Http.Headers;
 using Serilog;
-using Newtonsoft.Json;
 using Microsoft.AspNetCore.WebUtilities;
 
 namespace RelayDotNet
@@ -297,7 +296,7 @@ namespace RelayDotNet
                 WriteIndented = true,
             };
 
-            var dictionary = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(message, options);
+            var dictionary = JsonSerializer.Deserialize<Dictionary<string, object>>(message, options);
             if (dictionary == null)
             {
                 Log.Warning("{@WscInfo:l} OnMessage has null dictionary", WscInfo(webSocketConnection));
@@ -784,7 +783,7 @@ namespace RelayDotNet
             var options = new JsonSerializerOptions();
             options.Converters.Add(new DictionaryStringObjectJsonConverterCustomWrite());
             
-            return System.Text.Json.JsonSerializer.Serialize(dictionary, options);
+            return JsonSerializer.Serialize(dictionary, options);
         }
 
         private async Task<RunningRelayWorkflow> GetRunningRelayWorkflowOrThrow(IRelayWorkflow relayWorkflow)
@@ -1955,7 +1954,6 @@ namespace RelayDotNet
         string version = "relay-sdk-dotnet/2.0.0";
         string auth_hostname = "auth.relaygo.com";
 
-
         private async Task<string> UpdateAccessToken(string refreshToken, string clientId) {
             // Create a uri object with the following url
             string url = $"https://{auth_hostname}/oauth2/token";
@@ -1987,7 +1985,7 @@ namespace RelayDotNet
 
             // Create a json file with the grantResponse to make a dictionary, set the access 
             // token equal to the 'access_token' field, return that access token
-            Dictionary<string, object> dictionary = (Dictionary<string, object>) System.Text.Json.JsonSerializer.Deserialize(await grantResponse.Content.ReadAsStringAsync(), typeof(Dictionary<string, object>));
+            Dictionary<string, object> dictionary = (Dictionary<string, object>) JsonSerializer.Deserialize(await grantResponse.Content.ReadAsStringAsync(), typeof(Dictionary<string, object>));
             return (string) dictionary["access_token"].ToString();
         }
 
@@ -2054,7 +2052,10 @@ namespace RelayDotNet
 
             // Create the uri object, and serialize the payload
             Uri uri = new Uri(url);
-            var json = JsonConvert.SerializeObject(payload);
+
+            // var json = JsonConvert.SerializeObject(payload);
+            var json = JsonSerializer.Serialize<Dictionary<string, string>>(payload);
+
             var data = new StringContent(json, Encoding.UTF8, "application/json");
 
             // Post the request, await the response

--- a/RelayDotNet/Relay.cs
+++ b/RelayDotNet/Relay.cs
@@ -1950,7 +1950,7 @@ namespace RelayDotNet
             );
         }
 
-        string serverHostname = "all-main-pro-ibot.nocell.io";
+        string serverHostname = "all-main-pro-ibot.relaysvr.com";
         string version = "relay-sdk-dotnet/2.0.0";
         string auth_hostname = "auth.relaygo.com";
 
@@ -1983,8 +1983,8 @@ namespace RelayDotNet
                 throw new Exception($"Unable to get access token: {grantResponse.StatusCode}");
             }
 
-            // Create a json file with the grantResponse to make a dictionary, set the access 
-            // token equal to the 'access_token' field, return that access token
+            // Parse grantResponse content into an instance of a Dictionary type, set the access 
+            // token equal to the 'access_token' key's value in the dictionary and return the access token
             Dictionary<string, object> dictionary = (Dictionary<string, object>) JsonSerializer.Deserialize(await grantResponse.Content.ReadAsStringAsync(), typeof(Dictionary<string, object>));
             return (string) dictionary["access_token"].ToString();
         }

--- a/RelayDotNet/RelayDotNet.csproj
+++ b/RelayDotNet/RelayDotNet.csproj
@@ -6,6 +6,8 @@
 
     <ItemGroup>
       <PackageReference Include="Fleck" Version="1.2.0" />
+      <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Serilog" Version="2.11.0-dev-01371" />
       <PackageReference Include="Serilog.Enrichers.Thread" Version="3.2.0-dev-00752" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1-dev-00879" />

--- a/RelayDotNet/RelayDotNet.csproj
+++ b/RelayDotNet/RelayDotNet.csproj
@@ -7,7 +7,6 @@
     <ItemGroup>
       <PackageReference Include="Fleck" Version="1.2.0" />
       <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Serilog" Version="2.11.0-dev-01371" />
       <PackageReference Include="Serilog.Enrichers.Thread" Version="3.2.0-dev-00752" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1-dev-00879" />


### PR DESCRIPTION
Added http utilities that were included in relay-js api.ts file, but missing in dotnet SDK:
- TriggerWorkflow: starts a workflow through an HTTP POST
- FetchDevice: retrieves device info payload through an HTTP GET
- UpdateAccessToken: updates the user's access token if they receive a 401 when calling FetchDevice or TriggerWorkflow.
