### PR TITLE
Upgraded dotnet framework in .csproj files from 5.0 to 6.0

### DIFF
--- a/ConsoleAppSamples/ConsoleAppSamples.csproj
+++ b/ConsoleAppSamples/ConsoleAppSamples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/RelayDotNet/RelayDotNet.csproj
+++ b/RelayDotNet/RelayDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SamplesLibrary/SamplesLibrary.csproj
+++ b/SamplesLibrary/SamplesLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/WebAppSamples/WebAppSamples.csproj
+++ b/WebAppSamples/WebAppSamples.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
For dotnet, I've been using the dotnet framework 6.0 for development.  Since the version 5.0 runtime is no longer supported, I'm wondering if it would be a good idea to switch over the frameworks in the .csproj files to be 6.0, which is what I did here.