### PR TITLE
Added source_uri helper methods

### DIFF
--- a/RelayDotNet/Relay.cs
+++ b/RelayDotNet/Relay.cs
@@ -811,24 +811,6 @@ namespace RelayDotNet
         }
 
         /// <summary>
-        /// Get the source URN from a workflow trigger
-        /// </summary>
-        /// <param name="trigger">workflow trigger</param>
-        /// <returns>the source URN as a string from the trigger</returns>
-        public static string GetSourceUriFromTrigger(IDictionary<string, object> trigger) 
-        {
-            IDictionary<string, object> args = null;
-            string sourceUri = null;
-            if (trigger is not null) {
-                args = trigger["args"] as IDictionary<string, object>; 
-            }
-            if (args is not null) {
-                sourceUri = args["source_uri"] as string;
-            }
-            return sourceUri;
-        }
-
-        /// <summary>
         /// Creates a target object from a source URN.
         /// </summary>
         /// <param name="sourceUri">source uri that will be used to create a target.</param>
@@ -2389,7 +2371,12 @@ namespace RelayDotNet
             );
         }
 
-        public string GetSourceUriFromStartEvent(IDictionary<string, object> startEvent) {
+        /// <summary>
+        /// Parses out and retrieves the source URN from a Start Event
+        /// </summary>
+        /// <param name="startEvent">the start event</param>
+        /// <returns>the source URN</returns>
+        public static string GetSourceUriFromStartEvent(IDictionary<string, object> startEvent) {
             IDictionary<string, object> trigger = null;
             IDictionary<string, object> args = null;
             string sourceUri = null;

--- a/RelayDotNet/Relay.cs
+++ b/RelayDotNet/Relay.cs
@@ -809,6 +809,36 @@ namespace RelayDotNet
 
             return runningRelayWorkflow;
         }
+
+        /// <summary>
+        /// Get the source URN from a workflow trigger
+        /// </summary>
+        /// <param name="trigger">workflow trigger</param>
+        /// <returns>the source URN as a string from the trigger</returns>
+        public static string GetSourceUriFromTrigger(IDictionary<string, object> trigger) 
+        {
+            IDictionary<string, object> args = null;
+            string sourceUri = null;
+            if (trigger is not null) {
+                args = trigger["args"] as IDictionary<string, object>; 
+            }
+            if (args is not null) {
+                sourceUri = args["source_uri"] as string;
+            }
+            return sourceUri;
+        }
+
+        /// <summary>
+        /// Creates a target object from a source URN.
+        /// </summary>
+        /// <param name="sourceUri">source uri that will be used to create a target.</param>
+        /// <returns>the target that was created from a source URN.</returns>
+         public static Dictionary<string, object> TargetsFromSourceUri(string sourceUri) {
+            return new Dictionary<string, object>
+            {
+                ["uri"] = sourceUri
+            };
+         }
         
         /// <summary>
         /// Terminates a workflow.  This method is usually called


### PR DESCRIPTION
For ticket [PE-19581](https://republic-bts.atlassian.net/browse/PE-19581).  Added helper methods GetSourceUriFromTrigger() and TargetsFromSourceUri().  However, I'm not sure if GetSourceUriFromTrigger() is needed for dotnet, since I see there is already a GetSourceUriFromStartEvent() function, as seen being used in the HelloWorld sample.